### PR TITLE
Disable terminal.integrated.allowChords

### DIFF
--- a/config/vscode/settings.json
+++ b/config/vscode/settings.json
@@ -9,8 +9,8 @@
     ],
     "python.testing.unittestEnabled": false,
     "python.testing.pytestEnabled": true,
-    "python.showStartPage": false,
-    "window.restoreWindows": "none",
     "emacs-mcx.useMetaPrefixMacCmd": true,
-    "window.zoomLevel": 1,
+    "terminal.integrated.allowChords": false,
+    "window.restoreWindows": "none",
+    "window.zoomLevel": 1
 }


### PR DESCRIPTION
VS Codeのターミナル上でいくつかのショートカットキーが使えない問題を解消。
また、設定の並び替えを実施。