### PR TITLE
Load tmux-mem-cpu-load as a plugin

### DIFF
--- a/config/tmux/tmux.conf
+++ b/config/tmux/tmux.conf
@@ -18,7 +18,7 @@ setw -g window-status-current-format '[#I]'
 set -g status-left-length 20
 set -g status-left '#{?pane_synchronized,#[fg=brightred]*, }#[fg=blue,bold]#S#[default] '
 set -g status-right-length 60
-set -g status-right '#(tmux-mem-cpu-load -i5 -t1 -a0) | %m/%d(%a) %H:%M'
+set -g status-right '#(~/.config/tmux/plugins/tmux-mem-cpu-load/tmux-mem-cpu-load -i5 -t1 -a0) | %m/%d(%a) %H:%M'
 
 # ------------------------------
 # Misc
@@ -54,5 +54,6 @@ set -g @plugin 'tmux-plugins/tmux-sensible'
 set -g @plugin 'tmux-plugins/tmux-yank'
 set -g @plugin 'tmux-plugins/tmux-copycat'
 set -g @plugin 'tmux-plugins/tmux-pain-control'
+set -g @plugin 'thewtex/tmux-mem-cpu-load'
 
 run -b 'tmux-plugin-manager'


### PR DESCRIPTION
tmux-mem-cpu-loadをプラグインとして読み込む。
https://github.com/thewtex/tmux-mem-cpu-load#build-and-install-using-tpm

読み込んだときにtmux-mem-cpu-loadコマンドをビルドするのでcmakeが必要になる。