### PR TITLE
Run-shell in the foreground

### DIFF
--- a/config/tmux/tmux.conf
+++ b/config/tmux/tmux.conf
@@ -38,10 +38,10 @@ bind -Tcopy-mode k send -X cursor-up
 bind -Tcopy-mode l send -X cursor-right
 bind -Tcopy-mode w send -X copy-selection
 
-if -b '[ $(uname -s) = Darwin ]' ' \
+if '[ $(uname -s) = Darwin ]' ' \
     bind ] run "pbpaste | tmux loadb - && tmux pasteb"; \
 '
-if -b '[ $(uname -s) = Linux ]' ' \
+if '[ $(uname -s) = Linux ]' ' \
     bind ] run "xsel -bo | tmux loadb - && tmux pasteb"; \
 '
 
@@ -56,4 +56,4 @@ set -g @plugin 'tmux-plugins/tmux-copycat'
 set -g @plugin 'tmux-plugins/tmux-pain-control'
 set -g @plugin 'thewtex/tmux-mem-cpu-load'
 
-run -b 'tmux-plugin-manager'
+run 'tmux-plugin-manager'


### PR DESCRIPTION
tmux-sensibleが設定しているdefault-terminalが有効になる前にtmuxが起動していた。
そのためTERM環境変数が適切にscreen-256colorとならない事象が発生していた。

この問題を解消するため、tmux.confでバックグラウンド実行していた
シェルスクリプトをフォアグラウンド実行に変更する。