### PR TITLE
Revert to remove tmux-pain-control

### DIFF
--- a/config/emacs/init.el
+++ b/config/emacs/init.el
@@ -8,6 +8,7 @@
 
 ;;; Key bindings
 (define-key key-translation-map (kbd "C-h") (kbd "DEL"))
+(define-key key-translation-map (kbd "C-x j") (kbd "C-j"))
 (define-key global-map (kbd "C-x ?") 'help-command)
 
 ;;; Misc

--- a/config/tmux/tmux.conf
+++ b/config/tmux/tmux.conf
@@ -54,6 +54,7 @@ set -g @plugin 'tmux-plugins/tpm'
 set -g @plugin 'tmux-plugins/tmux-sensible'
 set -g @plugin 'tmux-plugins/tmux-yank'
 set -g @plugin 'tmux-plugins/tmux-copycat'
+set -g @plugin 'tmux-plugins/tmux-pain-control'
 set -g @plugin 'thewtex/tmux-mem-cpu-load'
 
 run 'tmux setenv -g TMUX_PLUGIN_MANAGER_PATH $HOME/.local/share/tmux/plugins'


### PR DESCRIPTION
painの分割ショートカットは割と使っていたことに気づいたので戻す。
C-jが入力できなくなる件については目下のところEmacsだけの問題なので、C-x jで代替することにする。