### PR TITLE
Remove commit.gpgsign and credential.helper

### DIFF
--- a/config/git/config
+++ b/config/git/config
@@ -1,14 +1,8 @@
 [core]
 	quotepath = false
-
-[commit]
-	gpgsign = true
-[credential "https://github.com"]
-	helper = !gh auth git-credential
 [ghq]
 	root = ~/.local/src
 [pager]
 	branch = cat
-
 [include]
 	path = config.local


### PR DESCRIPTION
コミット署名や認証ヘルパーは常に使うとも限らない設定なので、config.localの方へ移す。