### PR TITLE
Add fzf key-bindings.zsh on Debian

### DIFF
--- a/config/zsh/zshrc
+++ b/config/zsh/zshrc
@@ -44,6 +44,7 @@ if [[ $(uname -s) == Darwin ]]; then
 elif [[ $(uname -s) == Linux ]]; then
     alias ls='ls --color=auto'
     source-if-exists "/usr/share/fzf/shell/key-bindings.zsh"
+    source-if-exists "/usr/share/doc/fzf/examples/key-bindings.zsh"
 fi
 
 # ------------------------------


### PR DESCRIPTION
存在しなければ何もしないので既存の行を残しつつ追加